### PR TITLE
Add skip option to hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ export const Demo = () => {
   - `settings.enableHighAccuracy` - indicates the application would like to receive the most accurate results (default `false`),
   - `settings.timeout` - maximum length of time (in milliseconds) the device is allowed to take in order to return a position (default `Infinity`),
   - `settings.maximumAge` - the maximum age in milliseconds of a possible cached position that is acceptable to return (default `0`).
+- `skip: boolean` - set it to `true` to skip retrieving location.
 
 ### `usePosition()` output
 

--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {usePosition} from '../src/usePosition';
 
-export const Demo = ({watch, settings}) => {
+export const Demo = ({watch, settings, skip}) => {
   const {
     latitude,
     longitude,
@@ -11,7 +11,7 @@ export const Demo = ({watch, settings}) => {
     speed,
     heading,
     error,
-  } = usePosition(watch, settings);
+  } = usePosition(watch, settings, skip);
 
   const loader = !latitude && !error ? (
     <>
@@ -39,4 +39,5 @@ export const Demo = ({watch, settings}) => {
 Demo.propTypes = {
   watch: PropTypes.bool,
   settings: PropTypes.object,
+  skip: PropTypes.bool,
 };

--- a/src/usePosition.js
+++ b/src/usePosition.js
@@ -6,7 +6,7 @@ const defaultSettings = {
   maximumAge: 0,
 };
 
-export const usePosition = (watch = false, userSettings = {}) => {
+export const usePosition = (watch = false, userSettings = {}, skip = false) => {
   const settings = {
     ...defaultSettings,
     ...userSettings,
@@ -31,6 +31,10 @@ export const usePosition = (watch = false, userSettings = {}) => {
   };
 
   useEffect(() => {
+    if (skip) {
+      return;
+    }
+
     if (!navigator || !navigator.geolocation) {
       setError('Geolocation is not supported');
       return;
@@ -44,9 +48,11 @@ export const usePosition = (watch = false, userSettings = {}) => {
 
     navigator.geolocation.getCurrentPosition(onChange, onError, settings);
   }, [
+    watch,
     settings.enableHighAccuracy,
     settings.timeout,
     settings.maximumAge,
+    skip,
   ]);
 
   return {...position, error};

--- a/tests/__snapshots__/usePosition.test.js.snap
+++ b/tests/__snapshots__/usePosition.test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`usePosition should not call geolocation when skipped 1`] = `
+Array [
+  <div>
+    Trying to fetch location...
+  </div>,
+  <br />,
+  <code>
+    latitude: 
+    <br />
+    longitude: 
+    <br />
+    timestamp: 
+    <br />
+    accuracy: 
+    <br />
+    speed: 
+    <br />
+    heading: 
+    <br />
+    error: 
+  </code>,
+]
+`;
+
 exports[`usePosition should return empty values by default 1`] = `
 Array [
   <div>

--- a/tests/usePosition.test.js
+++ b/tests/usePosition.test.js
@@ -124,4 +124,22 @@ describe('usePosition', () => {
     const tree = testRenderer.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should not call geolocation when skipped', () => {
+    global.navigator.geolocation = {
+      watchPosition: jest.fn(),
+      getCurrentPosition: jest.fn(),
+      clearWatch: jest.fn(),
+    };
+
+    let testRenderer;
+    act(() => {
+      testRenderer = renderer.create(<Demo skip />);
+    });
+    const tree = testRenderer.toJSON();
+    expect(tree).toMatchSnapshot();
+
+    expect(global.navigator.geolocation.watchPosition).not.toHaveBeenCalled();
+    expect(global.navigator.geolocation.getCurrentPosition).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Allow geolocation to be skipped with an optional parameter. This is useful for cases where lat/lon can optionally be retrieved by other means (e.g., geocoding) and there is no need to get current location:

```javascript
  const {
    latitude,
    longitude,
    error,
  } = usePosition(watch, settings, otherLat && otherLon);

```